### PR TITLE
Remove duplicate routing rule in rendering_types.xml

### DIFF
--- a/obf_creation/rendering_types.xml
+++ b/obf_creation/rendering_types.xml
@@ -2478,7 +2478,6 @@
 		<routing_type tag="network" value="ncn" mode="register" base="true" relation="true"/>
 		<routing_type tag="network" value="icn" mode="register" base="true" relation="true"/>
 
-		<routing_type tag="access" mode="amend"/>
 		<!-- tag used as start with -->
 		<routing_type tag="access" mode="amend"/>
 		<routing_type tag="agricultural" mode="amend"/>
@@ -2513,7 +2512,7 @@
 		<routing_type tag="service" mode="amend"/>
 		<routing_type tag="ship" mode="amend"/>
 		<routing_type tag="toll" mode="amend" base="true"/>
-		<routing_type tag="toll_booth" mode="amend" base="true"/>
+		<routing_type tag="tourist_bus" mode="amend"/>
 		<routing_type tag="train" mode="amend"/>
 		<routing_type tag="tracktype" mode="amend"/>
 		<routing_type tag="sidewalk" mode="amend"/>


### PR DESCRIPTION
I think the access rule is duplicate. The "toll" key rule seems strange as there are no serious usages of such key in OSM data.
I add tourist_bus access key as that can be used similarly to "bus" in routing.
